### PR TITLE
Fix register name typo in comment

### DIFF
--- a/walkthrough/buffer-overflow-basic/exploit.py
+++ b/walkthrough/buffer-overflow-basic/exploit.py
@@ -35,7 +35,7 @@ if crash:
 # Fill out the buffer until where we control EIP
 exploit = cyclic(cyclic_find(0x6161616c))
 
-# Fill the spot we control EIP with a 'jmp eip'
+# Fill the spot we control EIP with a 'jmp esp'
 exploit += pack(jmp_esp)
 
 # Add our shellcode


### PR DESCRIPTION
The register name for the jmp command was incorrect in the comment. This updates it to match the variable.